### PR TITLE
Fix compiler config (#1)

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -1,10 +1,10 @@
 /*
- * NB: since truffle-hdwallet-provider 0.0.5 you must wrap HDWallet providers in a 
+ * NB: since truffle-hdwallet-provider 0.0.5 you must wrap HDWallet providers in a
  * function when declaring them. Failure to do so will cause commands to hang. ex:
  * ```
  * mainnet: {
- *     provider: function() { 
- *       return new HDWalletProvider(mnemonic, 'https://mainnet.infura.io/<infura-key>') 
+ *     provider: function() {
+ *       return new HDWalletProvider(mnemonic, 'https://mainnet.infura.io/<infura-key>')
  *     },
  *     network_id: '1',
  *     gas: 4500000,
@@ -14,8 +14,10 @@
 
 module.exports = {
   compilers: {
-    solc: '0.4.25'
-  }    
+    solc: {
+      version: '0.4.25'
+    }
+  }
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
 };


### PR DESCRIPTION
Not sure if this was just a breaking change w/ truffle 5.0 but previously running `truffle compile` [did not create a build directory for me](https://github.com/ConsenSys-Academy/simple-coin/issues/1).

I added the solc compiler version to a "version" key, as specified in the truffle documentation:
https://truffleframework.com/docs/truffle/reference/configuration#compiler-configuration